### PR TITLE
Fix modal display in IE11

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -375,6 +375,12 @@ header {
   text-align: left;
 }
 
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+	.remodal {
+    top: 20px;
+  }
+}
+
   .remodal .modal__header {
     background: #3596f4;
     padding: 10px;


### PR DESCRIPTION
Fixes /PulseTile/PulseTile-React-Core/issues/236

Added a small browser hack for IE11 which offsets the terms and conditions modal from the top of screen rather than vertically centred.

![screenshot 2019-01-31 at 14 38 58](https://user-images.githubusercontent.com/8059219/52061335-f858bb00-2565-11e9-9032-a9001d792152.png)

Only need to update the main.css to live for changes to take effect, no html changes required.